### PR TITLE
Bug fixes for TypeScript Chaining lesson

### DIFF
--- a/lessons/durablefunctions/chaining-ts.md
+++ b/lessons/durablefunctions/chaining-ts.md
@@ -13,7 +13,7 @@ This lessons consists of the following exercises:
 |0| [Prerequisites](#0-prerequisites)
 |1| [Introduction to Azure Durable Functions](#1-introduction-to-azure-durable-functions)
 |2| [Creating a Function App project for a Durable Function](#2-creating-a-function-app-project-for-a-durable-function)
-|3| [Implementing a "Real-World" Scenario](#3-implementing-a-"real-world"-scenario)
+|3| [Implementing a "Real-World" Scenario](#3-implementing-a-\"real-world\"-scenario)
 |4| [Retries - Dealing with Temporal Errors](#4-retries---dealing-with-temporal-errors)
 |5| [Circuit Breaker - Dealing with Timeouts](#5-circuit-breaker---dealing-with-timeouts)
 |6| [Homework](#6-homework)

--- a/src/typescript/durablefunctions/chaining/DurableFunctionApp-Retry/DurableFunctionsOrchestrator/function.json
+++ b/src/typescript/durablefunctions/chaining/DurableFunctionApp-Retry/DurableFunctionsOrchestrator/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/DurableFunctionsOrchestrator/index.js"
+}

--- a/src/typescript/durablefunctions/chaining/DurableFunctionApp-Retry/DurableFunctionsOrchestrator/index.ts
+++ b/src/typescript/durablefunctions/chaining/DurableFunctionApp-Retry/DurableFunctionsOrchestrator/index.ts
@@ -1,0 +1,13 @@
+﻿import * as df from "durable-functions"
+
+const orchestrator = df.orchestrator(function* (context) {
+    const outputs = []
+
+    outputs.push(yield context.df.callActivity("HelloCity", "Tokyo"))
+    outputs.push(yield context.df.callActivity("HelloCity", "Seattle"))
+    outputs.push(yield context.df.callActivity("HelloCity", "London"))
+
+    return outputs
+})
+
+export default orchestrator

--- a/src/typescript/durablefunctions/chaining/DurableFunctionApp-Timeout/DurableFunctionsOrchestrator/function.json
+++ b/src/typescript/durablefunctions/chaining/DurableFunctionApp-Timeout/DurableFunctionsOrchestrator/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/DurableFunctionsOrchestrator/index.js"
+}

--- a/src/typescript/durablefunctions/chaining/DurableFunctionApp-Timeout/DurableFunctionsOrchestrator/index.ts
+++ b/src/typescript/durablefunctions/chaining/DurableFunctionApp-Timeout/DurableFunctionsOrchestrator/index.ts
@@ -1,0 +1,13 @@
+﻿import * as df from "durable-functions"
+
+const orchestrator = df.orchestrator(function* (context) {
+    const outputs = []
+
+    outputs.push(yield context.df.callActivity("HelloCity", "Tokyo"))
+    outputs.push(yield context.df.callActivity("HelloCity", "Seattle"))
+    outputs.push(yield context.df.callActivity("HelloCity", "London"))
+
+    return outputs
+})
+
+export default orchestrator


### PR DESCRIPTION
This pull request contains two fixes:

- Navigation in toc was broken for section 3 -> fixed
- the `src` folder was not consistent with respect to the orchestrator function as reported via [Twitter](https://twitter.com/tino_scale_tone/status/1380683704641716224?s=20). -> fixed by adding orchestrator function