### PR TITLE
Missing {language} for test directory in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,5 +36,5 @@ An Azure Functions University lesson consists of several parts:
   - `lessons/{language}/prerequisites`
   - `lessons/{language}/{topic}`
   - `src/{language}/AzureFunctions.{Topic}`
-  - `test/{topic}` (REST Client files, if applicable)
+  - `test/{language}/{topic}` (REST Client files, if applicable)
   - `.tours/{language}/{topic}` (CodeTour files, if applicable)


### PR DESCRIPTION
Added the {language} part to the directory structure for tests