### PR TITLE
Badge for option to open in VSCode (remote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Azure Functions University
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/marcduiker/azure-functions-university)
+
+
 ![Zappy student](./img/zappy-university-192.gif)
 
 Welcome to Azure Functions University! 🎓


### PR DESCRIPTION
Added a badge to open the repo using the remote options of VSCode (remote repository or container) - see [https://open.vscode.dev/](https://open.vscode.dev/)

Not sure about the placing though, happy for feedback