### PR TITLE
GitHub Actions: Update Node.js version matrix in Typescript workflow

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The current version of the workflow contains as matrix for the Node.js versions the values: 10.x, 12.x and 14.x. The active as well as security support of version 10 of Node.js ended, the official LTS versions are 12.x, 14.x and 16.x (see <https://nodejs.org/en/about/releases/>) 

This pull request updates the Node.js versions in the GitHub Action `*.yml` file to the officially supported ones.

The workflow is still running successfully on the different lessons as the `npm build` is independent of the Azure Functions Core version. For reference see <https://github.com/lechnerc77/azure-functions-university/actions/runs/1646583108>. 
