### PR TITLE
Align with new dotnet template for .NET 6

### DIFF
--- a/.tours/dotnet6/http-refit/.tours/01-defining-a-third-party-rest-api.tour
+++ b/.tours/dotnet6/http-refit/.tours/01-defining-a-third-party-rest-api.tour
@@ -40,55 +40,55 @@
       "title": "Program.cs – Configuring HttpClient",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/Program.cs",
       "description": "This custom method holds the code that configures Refit to use the `IHttpBinOrgApi` interface as a proxy to the `Httpbin.org` third-party API.",
-      "line": 26
+      "line": 17
     },
     {
       "title": "Program.cs – Configuring base address and default HTTP headers",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/Program.cs",
       "description": "The `AddHttpClient()` call configures a *named* client with a base address and default HTTP headers.",
-      "line": 30
+      "line": 20
     },
     {
       "title": "Program.cs – Registering a strongly-typed proxy",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/Program.cs",
       "description": "The `AddTypedClient()` is a Refit-specific method that turns this configured `HttpClient` in a REST proxy using the strongly-typed `IHttpBinOrgApi` specification. This interface is then automatically registered into the dependency management system.",
-      "line": 31
+      "line": 21
     },
     {
       "title": "Program.cs – Importing Refit namespace",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/Program.cs",
       "description": "The `RestService` class used to configure Refit lives in the `Refit` namespace, which has been added at the top of the file.",
-      "line": 7
+      "line": 4
     },
     {
       "title": "Program.cs – Registering service contract using dependency injection",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/Program.cs",
       "description": "The custom `ConfigureServices` method matches the signature for the `HostBuilder.ConfigureServices()` method.\r\nThis call enables the configuration of Refit to take place and automatically injects the `IHttpBinOrgApi` interface to the dependency system.",
-      "line": 18
+      "line": 9
     },
     {
       "title": "HelloWorldHttpTrigger2.cs – Declaring IHttpBinOrgApi interface as a class member",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs",
       "description": "The `IHttpBinOrgApi` interface must be declared as a class member.",
-      "line": 12
+      "line": 10 
     },
     {
       "title": "HelloWorldHttpTrigger2.cs – Consuming IHttpBinOrg interface as an injected dependency",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs",
       "description": "An instance of the `IHttpBinOrgApi` type is automatically injected in the constructor, thanks to the configuration done in `Program.cs`.\r\nNotice that this instance is then assigned to the previously declared `_client` class member in the code below.",
-      "line": 16
+      "line": 14
     },
     {
       "title": "HelloWorldHttpTrigger2.cs – Consuming IHttpBinOrg interface as an injected dependency",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs",
       "description": "Calling a third-party API using the injected instance of the `IHttpBinOrgApi` type is done by invoking the corresponding method on the interface.",
-      "line": 32
+      "line": 30
     },
     {
       "title": "HelloWorldHttpTrigger2.cs – Calling third-party REST API using IHttpBinOrgApi interface",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs",
       "description": "Refit uses its own `Refit.ApiException` exception type to signal errors when making HTTP calls.\r\nThe code must therefore be protected against such occurrences with appropriate error handling.",
-      "line": 38
+      "line": 36
     }
   ],
   "isPrimary": true

--- a/.tours/dotnet6/http-refit/.tours/02-adding-custom-api-parameters.tour
+++ b/.tours/dotnet6/http-refit/.tours/02-adding-custom-api-parameters.tour
@@ -40,13 +40,13 @@
       "title": "HelloWorldHttpTrigger3.cs – Converting query string parameters to dictionary",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger3.cs",
       "description": "Using the `NameValueCollectionExtension` class’ `ToDictionary()` *extension method*, the query string parameters are converted to a dictionary to match the signature of the `query` parameter in the `IHttpBinOrg3.GetRequest()` method.",
-      "line": 31
+      "line": 28
     },
     {
       "title": "HelloWorldHttpTrigger3.cs – Specifying HTTP content and query string parameters",
       "file": "../../../src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger3.cs",
       "description": "The strongly-typed `GetRequestResponse` object returned by a call to the `IHttpBinOrg3.GetRequest()` method can now be sent directly back to the caller using the JSON serialization mechanism built into .NET 6.\r\n\r\nLikewize, the contents of the HTTP request sent to the third-party `Httpbin.org` API is taken from the body of the incoming HTTP request; whereas the custom query string parameters are specified as a dictionary.",
-      "line": 37
+      "line": 35
     }
   ]
 }

--- a/lessons/dotnet6/http-refit/README.md
+++ b/lessons/dotnet6/http-refit/README.md
@@ -143,13 +143,13 @@ This is a plain-text content.
 3. In `Program.cs`, let’s add a constant to hold the [Httpbin.org](http://httpbin.org/) API endpoint:
 
     ```csharp
-    private const string HttpBinOrgApiHost = "http://httpbin.org";
+    const string HttpBinOrgApiHost = "http://httpbin.org";
     ```
 
 4. In `Program.cs`, add the following code:
 
     ```csharp
-    private static void ConfigureServices(HostBuilderContext builder, IServiceCollection services)
+    static void ConfigureServices(HostBuilderContext builder, IServiceCollection services)
     {
         services
             .AddHttpClient("HttpBinOrgApi", (provider, client) =>

--- a/src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger1.cs
+++ b/src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger1.cs
@@ -3,28 +3,25 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
-namespace AzFuncUni.Http
+public class HelloWorldHttpTrigger1
 {
-    public class HelloWorldHttpTrigger1
-    {
-        private readonly ILogger _logger;
+	private readonly ILogger _logger;
 
-        public HelloWorldHttpTrigger1(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<HelloWorldHttpTrigger1>();
-        }
+	public HelloWorldHttpTrigger1(ILoggerFactory loggerFactory)
+	{
+		_logger = loggerFactory.CreateLogger<HelloWorldHttpTrigger1>();
+	}
 
-        [Function("HelloWorldHttpTrigger1")]
-        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
-        {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
+	[Function("HelloWorldHttpTrigger1")]
+	public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
+	{
+		_logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            var response = req.CreateResponse(HttpStatusCode.OK);
-            response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+		var response = req.CreateResponse(HttpStatusCode.OK);
+		response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
 
-            response.WriteString("Welcome to Azure Functions!");
+		response.WriteString("Welcome to Azure Functions!");
 
-            return response;
-        }
-    }
+		return response;
+	}
 }

--- a/src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs
+++ b/src/dotnet6/http-refit/AzFuncUni.Http/HelloWorldHttpTrigger2.cs
@@ -4,45 +4,42 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
-namespace AzFuncUni.Http
+public class HelloWorldHttpTrigger2
 {
-	public class HelloWorldHttpTrigger2
+	private readonly ILogger _logger;
+	private readonly IHttpBinOrgApi _client;
+
+	public HelloWorldHttpTrigger2(
+		ILoggerFactory loggerFactory,
+		IHttpBinOrgApi client
+	)
 	{
-		private readonly ILogger _logger;
-		private readonly IHttpBinOrgApi _client;
+		_logger = loggerFactory.CreateLogger<HelloWorldHttpTrigger2>();
+		_client = client;
+	}
 
-		public HelloWorldHttpTrigger2(
-			ILoggerFactory loggerFactory,
-			IHttpBinOrgApi client
-		)
+	[Function(nameof(HelloWorldHttpTrigger2))]
+	public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
+	{
+		_logger.LogInformation("C# HTTP trigger function processed a request.");
+
+		var response = req.CreateResponse(HttpStatusCode.OK);
+
+		try
 		{
-			_logger = loggerFactory.CreateLogger<HelloWorldHttpTrigger2>();
-			_client = client;
+			var content = await _client.GetRequest();
+			var text = await content.ReadAsStringAsync();
+
+			response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+			await response.WriteStringAsync(text);
+		}
+		catch (Refit.ApiException e)
+		{
+			response.StatusCode = HttpStatusCode.InternalServerError;
+			response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+			await response.WriteStringAsync(e.Message);
 		}
 
-		[Function(nameof(HelloWorldHttpTrigger2))]
-		public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
-		{
-			_logger.LogInformation("C# HTTP trigger function processed a request.");
-
-			var response = req.CreateResponse(HttpStatusCode.OK);
-
-			try
-			{
-				var content = await _client.GetRequest();
-				var text = await content.ReadAsStringAsync();
-
-				response.Headers.Add("Content-Type", "application/json; charset=utf-8");
-				await response.WriteStringAsync(text);
-			}
-			catch (Refit.ApiException e)
-			{
-				response.StatusCode = HttpStatusCode.InternalServerError;
-				response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-				await response.WriteStringAsync(e.Message);
-			}
-
-			return response;
-		}
+		return response;
 	}
 }

--- a/src/dotnet6/http-refit/AzFuncUni.Http/Program.cs
+++ b/src/dotnet6/http-refit/AzFuncUni.Http/Program.cs
@@ -1,44 +1,32 @@
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Azure.Functions.Worker.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using Refit;
 using System.Net.Http;
 
-namespace src
+var builder = new HostBuilder()
+	.ConfigureFunctionsWorkerDefaults()
+	.ConfigureServices(ConfigureServices)
+	;
+
+var host = builder.Build();
+
+host.Run();
+
+const string HttpBinOrgApiHost = "http://httpbin.org";
+static void ConfigureServices(HostBuilderContext builder, IServiceCollection services)
 {
-	public class Program
-	{
-		public static void Main()
-		{
-			var builder = new HostBuilder()
-				.ConfigureFunctionsWorkerDefaults()
-				.ConfigureServices(ConfigureServices)
-				;
+	services
+		.AddHttpClient(nameof(IHttpBinOrgApi), ConfigureHttpClient)
+		.AddTypedClient(c => RestService.For<IHttpBinOrgApi>(c));
 
-			var host = builder.Build();
+	services
+		.AddHttpClient(nameof(IHttpBinOrgApi3), ConfigureHttpClient)
+		.AddTypedClient(c => RestService.For<IHttpBinOrgApi3>(c));
+}
 
-			host.Run();
-		}
-
-		private const string HttpBinOrgApiHost = "http://httpbin.org";
-		private static void ConfigureServices(HostBuilderContext builder, IServiceCollection services)
-		{
-			services
-				.AddHttpClient(nameof(IHttpBinOrgApi), ConfigureHttpClient)
-				.AddTypedClient(c => RestService.For<IHttpBinOrgApi>(c));
-
-			services
-				.AddHttpClient(nameof(IHttpBinOrgApi3), ConfigureHttpClient)
-				.AddTypedClient(c => RestService.For<IHttpBinOrgApi3>(c));
-		}
-
-		private static void ConfigureHttpClient(IServiceProvider provider, HttpClient client)
-		{
-			client.BaseAddress = new System.Uri(HttpBinOrgApiHost);
-			client.DefaultRequestHeaders.Add("Accept", "application/json");
-		}
-	}
+static void ConfigureHttpClient(IServiceProvider provider, HttpClient client)
+{
+	client.BaseAddress = new System.Uri(HttpBinOrgApiHost);
+	client.DefaultRequestHeaders.Add("Accept", "application/json");
 }


### PR DESCRIPTION
Fixes #202 - The new .NET 6 dotnet template for C#-based Function Apps omits namespace declarations.

This PR includes the following changes:

- [x] Updated the source code to remove namespace declarations and adapt static method declarations.
- [x] Lesson README.md is complete. Updated a couple of declarations for static methods in `Program.cs`.
- [x] A CodeTour is available for each exercise in the lesson. Update line numbers in CodeTour files.
