### PR TITLE
Update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,11 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "marcduiker"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+     # Check for updates to GitHub Actions once a week on Monday
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10      

--- a/.github/workflows/code-tour-and-links-watcher.yml
+++ b/.github/workflows/code-tour-and-links-watcher.yml
@@ -17,14 +17,14 @@ jobs:
               uses: actions/checkout@v2
         
             - name: 'Watch CodeTour changes'
-              uses: pozil/codetour-watch@v1.3.0
+              uses: pozil/codetour-watch@v1.6.3
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   tour-path: '.tours/'
             
             - name: Link Checker
               id: lychee
-              uses: lycheeverse/lychee-action@v1.4.1
+              uses: lycheeverse/lychee-action@v1.5.4
               with:
                 fail: true
                 args: --verbose --no-progress --max-concurrency 2 --exclude-mail --exclude-loopback './**/*.md'

--- a/.github/workflows/links-watcher-schedule.yml
+++ b/.github/workflows/links-watcher-schedule.yml
@@ -14,17 +14,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Checkout source code'
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Link Checker
               id: lychee
-              uses: lycheeverse/lychee-action@v1.4.1
+              uses: lycheeverse/lychee-action@v1.5.4
               with:
                 args: --verbose --no-progress --max-concurrency 2 --exclude-mail --exclude-loopback './**/*.md'
                 output: ./lychee/out.md
               env:
                 GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
             - name: Create issue when fail
-              uses: peter-evans/create-issue-from-file@v3
+              uses: peter-evans/create-issue-from-file@v4
               if: ${{ steps.lychee.outputs.exit_code }} != 0
               with:
                 title: Link Checker Report


### PR DESCRIPTION
Several GH Actions are outdated (see e.g. detailed output of link checks) in using deprecated environments like Node.js 12.

This PR updates the following actions to the latest stable verion:

- [GitHub checkout](https://github.com/actions/checkout)
- [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action/releases/tag/v1.5.4)
- [pozil/codetour-watch](https://github.com/pozil/codetour-watch/releases/tag/v1.6.3)
- [peter-evans/create-issue-from-file](https://github.com/peter-evans/create-issue-from-file/releases/tag/v4.0.1)

In order to avoid manual checking of the actions, this PR ads the GH Actions to the dependabot configuration