### PR TITLE
Downgrade lychee action to 1.5.3

### DIFF
--- a/.github/workflows/code-tour-and-links-watcher.yml
+++ b/.github/workflows/code-tour-and-links-watcher.yml
@@ -24,7 +24,7 @@ jobs:
             
             - name: Link Checker
               id: lychee
-              uses: lycheeverse/lychee-action@v1.5.4
+              uses: lycheeverse/lychee-action@v1.5.3
               with:
                 fail: true
                 args: --verbose --no-progress --max-concurrency 2 --exclude-mail --exclude-loopback './**/*.md'

--- a/.github/workflows/links-watcher-schedule.yml
+++ b/.github/workflows/links-watcher-schedule.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v3
             - name: Link Checker
               id: lychee
-              uses: lycheeverse/lychee-action@v1.5.4
+              uses: lycheeverse/lychee-action@v1.5.3
               with:
                 args: --verbose --no-progress --max-concurrency 2 --exclude-mail --exclude-loopback './**/*.md'
                 output: ./lychee/out.md


### PR DESCRIPTION
There seems to be an issue with the lychee action in version 1.5.4 and links to Twitter that constantly time out. 
This issue is not present in version 1.5.3, so this pull request provides the code to downgrade the version accordingly. 

This should resolve the issue #381 with the timeout errors