### PR TITLE
Ignore Twitter links in lychee link checks

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,4 @@ https://docs.github.com*
 https://github.com/marcduiker/azure-functions-university/discussions/new?*
 https://github.com/marcduiker/functionapp-deployment/generate
 https://getresumeapi-azuni.azurewebsites.net*
+https://twitter.com/*


### PR DESCRIPTION
This PR adds Twitter links to the `lycheeignore` file.

Currently the checks are very unstable due to issues with Twitter and cause a lot of noise in the automatically created issues.
As they can be easily checked manually and do not change, the exclusion shouldn't impact the quality of the checked links.

Closes issue #386 